### PR TITLE
Unpatch only the patches from the plugin

### DIFF
--- a/SCP294.cs
+++ b/SCP294.cs
@@ -64,7 +64,7 @@ namespace SCP294
 
             Timing.KillCoroutines(hintCoroutine);
 
-            _harmony.UnpatchAll();
+            _harmony.UnpatchAll(_harmony.Id);
             _harmony = null;
 
             Log.Info("Disabled Plugin Successfully");


### PR DESCRIPTION
The `UnpatchAll()` method is unpatching all patches applied with Harmony, including patches that are not from the plugin.

https://harmony.pardeike.net/articles/basics.html#unpatching